### PR TITLE
added comments and inline type hinting for lib and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,29 @@ Each example has a README.md file that shows how to execute it. All the examples
 
 For example, to publish message to RabbitMQ is as simple as this:
 
-		$producer = new Thumper\Producer(HOST, PORT, USER, PASS, VHOST);
-		$producer->setExchangeOptions(array('name' => 'hello-exchange', 'type' => 'direct'));
-		$producer->publish($argv[1]);
+```php
+<?php
+$producer = new Thumper\Producer(HOST, PORT, USER, PASS, VHOST);
+$producer->setExchangeOptions(array('name' => 'hello-exchange', 'type' => 'direct'));
+$producer->publish($argv[1]);
+```
 
 And then to consume them on the other side of the wire:
 
-		$myConsumer = function($msg)
-		{
-		  echo $msg, "\n";
-		};
+```php
 
-		$consumer = new Thumper\Consumer(HOST, PORT, USER, PASS, VHOST);
-		$consumer->setExchangeOptions(array('name' => 'hello-exchange', 'type' => 'direct'));
-		$consumer->setQueueOptions(array('name' => 'hello-queue'));
-		$consumer->setCallback($myConsumer); //myConsumer could be any valid PHP callback
-		$consumer->consume(5); //5 is the number of messages to consume.
+<?php
+$myConsumer = function($msg)
+{
+  echo $msg, "\n";
+};
+
+$consumer = new Thumper\Consumer(HOST, PORT, USER, PASS, VHOST);
+$consumer->setExchangeOptions(array('name' => 'hello-exchange', 'type' => 'direct'));
+$consumer->setQueueOptions(array('name' => 'hello-queue'));
+$consumer->setCallback($myConsumer); //myConsumer could be any valid PHP callback
+$consumer->consume(5); //5 is the number of messages to consume.
+```
 
 ## Queue Server ##
 

--- a/config/config.php
+++ b/config/config.php
@@ -1,7 +1,51 @@
 <?php
+/**
+ * The MIT License
+ *
+ * Copyright (c) 2010 Alvaro Videla
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ * @category   Thumper
+ * @package    Thumper
+ */
+
 require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+/**
+ * AMQP Host
+ */
 define('HOST', 'localhost');
+/**
+ * AMQP Port
+ */
 define('PORT', 5672);
+/**
+ * AMQP user
+ */
 define('USER', 'guest');
+/**
+ * AMQP users password
+ */
 define('PASS', 'guest');
+/**
+ * AMQP vhost to bind to
+ */
 define('VHOST', '/');

--- a/examples/parallel_processing/char_count_server.php
+++ b/examples/parallel_processing/char_count_server.php
@@ -23,18 +23,21 @@
  * SOFTWARE.
  *
  *
- * @category   Thumper
- * @package    Thumper
+ * @package     Thumper
+ * @category    Thumper
+ * @subcategory Examples
  */
 
 require_once(dirname(dirname(__DIR__)) . '/config/config.php');
 
 $charCount = function($word)
 {
-  sleep(2);
-  return strlen($word);
+    sleep(2);
+    return strlen($word);
 };
-
+/*
+ * Begin Processing requests
+ */
 $server = new Thumper\RpcServer(HOST, PORT, USER, PASS, VHOST);
 $server->initServer('charcount');
 $server->setCallback($charCount);

--- a/examples/parallel_processing/parallel_rpc.php
+++ b/examples/parallel_processing/parallel_rpc.php
@@ -23,8 +23,9 @@
  * SOFTWARE.
  *
  *
- * @category   Thumper
- * @package    Thumper
+ * @package     Thumper
+ * @category    Thumper
+ * @subcategory Examples
  */
 require_once(dirname(dirname(__DIR__)) . '/config/config.php');
 
@@ -32,12 +33,21 @@ $start = time();
 
 $client = new Thumper\RpcClient(HOST, PORT, USER, PASS, VHOST);
 $client->initClient();
-$client->addRequest($argv[1], 'charcount', 'charcount'); //charcount is the request identifier
-$client->addRequest(serialize(array('min' => 0, 'max' => (int) $argv[2])), 'random-int', 'random-int'); //random-int is the request identifier
-echo "Waiting for replies…\n";
+
+$client->addRequest(
+    $argv[ 1 ], 'charcount', 'charcount'
+); //charcount is the request identifier
+
+$client->addRequest(
+    serialize(array( 'min' => 0, 'max' => (int)$argv[ 2 ] )), 'random-int',
+    'random-int'
+); //random-int is the request identifier
+
+echo 'Waiting for replies…', PHP_EOL;
+
 $replies = $client->getReplies();
 
 var_dump($replies);
 
-echo "Total time: ", time() - $start, "\n";
+echo "Total time: ", time() - $start, PHP_EOL;
 

--- a/examples/parallel_processing/random_int_server.php
+++ b/examples/parallel_processing/random_int_server.php
@@ -23,16 +23,17 @@
  * SOFTWARE.
  *
  *
- * @category   Thumper
- * @package    Thumper
+ * @package     Thumper
+ * @category    Thumper
+ * @subcategory Examples
  */
 require_once(dirname(dirname(__DIR__)) . '/config/config.php');
 
 $randomInt = function($data)
 {
-  sleep(5);
-  $data = unserialize($data);
-  return rand($data['min'], $data['max']);
+    sleep(5);
+    $data = unserialize($data);
+    return rand($data[ 'min' ], $data[ 'max' ]);
 };
 
 $server = new Thumper\RpcServer(HOST, PORT, USER, PASS, VHOST);

--- a/examples/queue_server/consumer.php
+++ b/examples/queue_server/consumer.php
@@ -23,20 +23,33 @@
  * SOFTWARE.
  *
  *
- * @category   Thumper
- * @package    Thumper
+ * @package     Thumper
+ * @category    Thumper
+ * @subcategory Examples
  */
 
 require_once(dirname(dirname(__DIR__)) . '/config/config.php');
 
 $myConsumer = function($msg)
 {
-  echo $msg, "\n";
+    echo $msg, PHP_EOL;
 };
 
 $consumer = new Thumper\Consumer(HOST, PORT, USER, PASS, VHOST);
-$consumer->setExchangeOptions(array('name' => 'hello-exchange', 'type' => 'direct'));
-$consumer->setQueueOptions(array('name' => 'hello-queue'));
-$consumer->setCallback($myConsumer); //myConsumer could be any valid PHP callback
-$consumer->consume(5); //5 is the number of messages to consume
+$consumer->setExchangeOptions(
+    array( 'name' => 'hello-exchange', 'type' => 'direct' )
+);
+$consumer->setQueueOptions(array( 'name' => 'hello-queue' ));
+
+/*
+ * $myConsumer could be any valid PHP callback
+ */
+$consumer->setCallback(
+    $myConsumer
+);
+
+/*
+ * 5 is the number of messages to consume
+ */
+$consumer->consume(5);
 

--- a/examples/queue_server/producer.php
+++ b/examples/queue_server/producer.php
@@ -23,13 +23,18 @@
  * SOFTWARE.
  *
  *
- * @category   Thumper
- * @package    Thumper
+ * @package     Thumper
+ * @category    Thumper
+ * @subcategory Examples
  */
 
 require_once(dirname(dirname(__DIR__)) . '/config/config.php');
 
 $producer = new Thumper\Producer(HOST, PORT, USER, PASS, VHOST);
-$producer->setExchangeOptions(array('name' => 'hello-exchange', 'type' => 'direct'));
-$producer->publish($argv[1]); //The first argument will be the published message
+$producer->setExchangeOptions(
+    array( 'name' => 'hello-exchange', 'type' => 'direct' )
+);
+$producer->publish(
+    $argv[ 1 ]
+); //The first argument will be the published message
 

--- a/examples/rpc/rpc_client.php
+++ b/examples/rpc/rpc_client.php
@@ -23,16 +23,24 @@
  * SOFTWARE.
  *
  *
- * @category   Thumper
- * @package    Thumper
+ * @package     Thumper
+ * @category    Thumper
+ * @subcategory Examples
  */
 
 require_once(dirname(dirname(__DIR__)) . '/config/config.php');
 
 $client = new Thumper\RpcClient(HOST, PORT, USER, PASS, VHOST);
 $client->initClient();
-$client->addRequest($argv[1], 'charcount', 'charcount'); //the third parameter is the request identifier
-echo "Waiting for replies…\n";
+/*
+ * the third parameter is the request identifier
+ */
+$client->addRequest(
+    $argv[ 1 ], 'charcount', 'charcount'
+);
+
+echo 'Waiting for replies…', PHP_EOL;
+
 $replies = $client->getReplies();
 
 var_dump($replies);

--- a/examples/topic/anon_consumer.php
+++ b/examples/topic/anon_consumer.php
@@ -23,20 +23,27 @@
  * SOFTWARE.
  *
  *
- * @category   Thumper
- * @package    Thumper
+ * @package     Thumper
+ * @category    Thumper
+ * @subcategory Examples
  */
 
 require_once(dirname(dirname(__DIR__)) . '/config/config.php');
 
 $myConsumer = function($msg)
 {
-  echo $msg, "\n";
+    echo $msg, PHP_EOL;
 };
 
 $consumer = new Thumper\AnonConsumer(HOST, PORT, USER, PASS, VHOST);
-$consumer->setExchangeOptions(array('name' => 'logs-exchange', 'type' => 'topic'));
-$consumer->setRoutingKey($argv[1]);
+$consumer->setExchangeOptions(
+    array( 'name' => 'logs-exchange', 'type' => 'topic' )
+);
+$consumer->setRoutingKey($argv[ 1 ]);
 $consumer->setCallback($myConsumer);
+
+/*
+ * the number of messages to consume,
+ */
 $consumer->consume(5);
 

--- a/examples/topic/topic_consumer.php
+++ b/examples/topic/topic_consumer.php
@@ -23,20 +23,27 @@
  * SOFTWARE.
  *
  *
- * @category   Thumper
- * @package    Thumper
+ * @package     Thumper
+ * @category    Thumper
+ * @subcategory Examples
  */
 
 require_once(dirname(dirname(__DIR__)) . '/config/config.php');
 
 $myConsumer = function($msg)
 {
-  echo $msg, "\n";
+    echo $msg, PHP_EOL;
 };
 
 $consumer = new Thumper\Consumer(HOST, PORT, USER, PASS, VHOST);
-$consumer->setExchangeOptions(array('name' => 'logs-exchange', 'type' => 'topic'));
-$consumer->setQueueOptions(array('name' => $argv[2] . '-queue'));
-$consumer->setRoutingKey($argv[1]);
+$consumer->setExchangeOptions(
+    array( 'name' => 'logs-exchange', 'type' => 'topic' )
+);
+$consumer->setQueueOptions(array( 'name' => $argv[ 2 ] . '-queue' ));
+$consumer->setRoutingKey($argv[ 1 ]);
 $consumer->setCallback($myConsumer);
+
+/*
+ * the number of messages to consume
+ */
 $consumer->consume(5);

--- a/examples/topic/topic_producer.php
+++ b/examples/topic/topic_producer.php
@@ -23,12 +23,15 @@
  * SOFTWARE.
  *
  *
- * @category   Thumper
- * @package    Thumper
+ * @package     Thumper
+ * @category    Thumper
+ * @subcategory Examples
  */
 
 require_once(dirname(dirname(__DIR__)) . '/config/config.php');
 
 $producer = new Thumper\Producer(HOST, PORT, USER, PASS, VHOST);
-$producer->setExchangeOptions(array('name' => 'logs-exchange', 'type' => 'topic'));
-$producer->publish($argv[1], sprintf('%s.%s', $argv[2], $argv[3]));
+$producer->setExchangeOptions(
+    array( 'name' => 'logs-exchange', 'type' => 'topic' )
+);
+$producer->publish($argv[ 1 ], sprintf('%s.%s', $argv[ 2 ], $argv[ 3 ]));

--- a/lib/Thumper/AnonConsumer.php
+++ b/lib/Thumper/AnonConsumer.php
@@ -28,21 +28,31 @@
  */
 namespace Thumper;
 use Thumper\Consumer;
+
 /**
- *
- *
- *
  * @category   Thumper
  * @package    Thumper
  */
 class AnonConsumer extends Consumer
 {
-  public function __construct($host, $port, $user, $pass, $vhost)
-  {
-    parent::__construct(HOST, PORT, USER, PASS, VHOST);
 
-    $this->setQueueOptions(array('name' => '', 'passive' => false, 'durable' => false,
-                                     'exclusive' => true, 'auto_delete' => true, 'nowait' => false,
-                                     'arguments' => null, 'ticket' => null));
-  }
+    /**
+     * @param string $host
+     * @param int    $port
+     * @param string $user
+     * @param string $pass
+     * @param string $vhost
+     */
+    public function __construct($host, $port, $user, $pass, $vhost)
+    {
+        parent::__construct(HOST, PORT, USER, PASS, VHOST);
+
+        $this->setQueueOptions(
+            array(
+                 'name' => '', 'passive' => false, 'durable' => false,
+                 'exclusive' => true, 'auto_delete' => true, 'nowait' => false,
+                 'arguments' => null, 'ticket' => null
+            )
+        );
+    }
 }

--- a/lib/Thumper/BaseConsumer.php
+++ b/lib/Thumper/BaseConsumer.php
@@ -28,20 +28,25 @@
  */
 namespace Thumper;
 use Thumper\BaseAmqp;
+
 /**
- *
- *
- *
  * @category   Thumper
  * @package    Thumper
  */
 class BaseConsumer extends BaseAmqp
 {
-  protected $callback;
 
-  public function setCallback($callback)
-  {
-    $this->callback = $callback;
-  }
+    /**
+     * @var callable|string|array
+     */
+    protected $callback;
+
+    /**
+     * @param callable|string|array $callback
+     */
+    public function setCallback($callback)
+    {
+        $this->callback = $callback;
+    }
 }
 

--- a/lib/Thumper/Producer.php
+++ b/lib/Thumper/Producer.php
@@ -28,6 +28,7 @@
  */
 namespace Thumper;
 use PhpAmqpLib\Message\AMQPMessage;
+
 /**
  *
  *
@@ -37,17 +38,35 @@ use PhpAmqpLib\Message\AMQPMessage;
  */
 class Producer extends BaseAmqp
 {
+
+    /**
+     * @var bool
+     */
     protected $exchangeReady = false;
 
+    /**
+     * @param string $msgBody
+     * @param string $routingKey
+     */
     public function publish($msgBody, $routingKey = '')
     {
         if (!$this->exchangeReady) {
             //declare a durable non autodelete exchange
-            $this->ch->exchange_declare($this->exchangeOptions['name'], $this->exchangeOptions['type'], false, true, false);
+            $this->ch->exchange_declare(
+                $this->exchangeOptions[ 'name' ],
+                $this->exchangeOptions[ 'type' ], false, true, false
+            );
             $this->exchangeReady = true;
         }
 
-        $msg = new AMQPMessage($msgBody, array('content_type' => 'text/plain', 'delivery_mode' => 2));
-        $this->ch->basic_publish($msg, $this->exchangeOptions['name'], $routingKey);
+        $msg = new AMQPMessage(
+            $msgBody, array(
+                 'content_type' => 'text/plain',
+                 'delivery_mode' => 2
+            )
+        );
+        $this->ch->basic_publish(
+            $msg, $this->exchangeOptions[ 'name' ], $routingKey
+        );
     }
 }


### PR DESCRIPTION
please confirm that type hinting for the AMQPMessage params is acceptable
I am not certain of this should there be use cases of user defined objects
that may `look` like an AMQPMessage object but not inherit, however I do not anticipate issues.
example: `\\Thumper\\Consumer::maybeStopConsumer` method.

I will probably look to adding tests in the near future and more details regarding the use case examples 
this library present.

This PR also reformats much of the code to additional PSR-2 standards.

also ref: #Num: #7
