### PR TITLE
specify stable version php-amqplib in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "videlalvaro/php-amqplib" : "dev-master"
+        "videlalvaro/php-amqplib" : "~2.1.0"
     }
 }


### PR DESCRIPTION
Use stable version php-amqplib, so Thumper can be easily installed in production via composer.
