### PR TITLE
Fix forgotten parameter while catching exception

### DIFF
--- a/lib/Thumper/RpcServer.php
+++ b/lib/Thumper/RpcServer.php
@@ -78,7 +78,8 @@ class RpcServer extends BaseConsumer
         } catch (Exception $e) {
             $this->sendReply(
                 'error: ' . $e->getMessage(),
-                $msg->get('reply_to')
+                $msg->get('reply_to'),
+                $msg->get('correlation_id')
             );
         }
     }


### PR DESCRIPTION
Missing `correlation_id` parameter
