### PR TITLE
Remove destruct BaseAmqp

### DIFF
--- a/lib/Thumper/BaseAmqp.php
+++ b/lib/Thumper/BaseAmqp.php
@@ -87,12 +87,6 @@ class BaseAmqp
         $this->ch = $this->conn->channel();
     }
 
-    public function __destruct()
-    {
-        $this->ch->close();
-        $this->conn->close();
-    }
-
     public function setExchangeOptions($options)
     {
         if (empty($options['name'])) {


### PR DESCRIPTION
Close connection is already managed in `destruct` method of `AMQPConnection` class

If we keep this destruct, it will be called first and will close connection.
Then `AMQPConnection` destruct method will be called, and if `close_on_destruct` property is true, will try to close again... and we will get an exception.

Am I wrong ? Should we not let Connection manage closing itself ?
