### PR TITLE
Allows to specify routingKey before publishing a msg.

### DIFF
--- a/lib/Thumper/Producer.php
+++ b/lib/Thumper/Producer.php
@@ -46,7 +46,7 @@ class Producer extends BaseAmqp
 {
     protected $exchangeReady = false;
 
-    public function publish($msgBody, $routingKey = '')
+    public function publish($msgBody, $routingKey = false)
     {
         if (!$this->exchangeReady) {
             //declare a durable non autodelete exchange
@@ -67,7 +67,7 @@ class Producer extends BaseAmqp
         $this->ch->basic_publish(
             $msg,
             $this->exchangeOptions['name'],
-            $routingKey
+            $routingKey ?: $this->routingKey
         );
     }
 }


### PR DESCRIPTION
No change to current behavior. If you specify `routingKey` when you call `publish` method, it will still be used.
