### PR TITLE
update deps and bump version to 0.3.3 please

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "videlalvaro/php-amqplib" : "~2.1.0"
+        "videlalvaro/php-amqplib" : "~2.4.0"
     }
 }


### PR DESCRIPTION
please do this to update dependencies. now it says this:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - videlalvaro/thumper v0.3.2 requires videlalvaro/php-amqplib ~2.1.0 -> no matching package found.
    - videlalvaro/thumper v0.3.2 requires videlalvaro/php-amqplib ~2.1.0 -> no matching package found.
    - videlalvaro/thumper v0.3.2 requires videlalvaro/php-amqplib ~2.1.0 -> no matching package found.
    - Installation request for videlalvaro/thumper 0.3.2 -> satisfiable by videlalvaro/thumper[v0.3.2].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```
